### PR TITLE
Prevent spellcheck in quickfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.tap
 doc/*.description
 doc/*.install
+doc/tags

--- a/autoload/SpellCheck/quickfix.vim
+++ b/autoload/SpellCheck/quickfix.vim
@@ -120,6 +120,10 @@ function! SpellCheck#quickfix#List( firstLine, lastLine, isNoJump, isUseLocation
 	return 2
     endif
 
+    if &ft == "qf"
+	return 2
+    endif
+
     let [l:types, l:predicates] = SpellCheck#ParseArguments(a:arguments)
     let l:save_view = winsaveview()
     try


### PR DESCRIPTION
If the quickfix window is currently active, `:SpellCheck` will do a spellcheck of it's own output and put that into the quickfix window. 
This patch simply ignores the `:SpellCheck` call in the quickfix window.